### PR TITLE
Don't fail the build on checkstyle warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 checkstyle {
-  maxWarnings = 0
   toolVersion = '8.4'
   // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
   configDir = new File(rootDir, 'config/checkstyle')


### PR DESCRIPTION
We'll need the same change for spring-boot-template
