### PR TITLE
Make Quartz use PostgreSQL database as the job store

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/QuartzConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/QuartzConfiguration.java
@@ -3,19 +3,33 @@ package uk.gov.hmcts.reform.jobscheduler.config;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.impl.StdSchedulerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
 import javax.inject.Singleton;
 
 @Configuration
+@ConfigurationProperties
 public class QuartzConfiguration {
+
+    private final Map<String, String> quartzProperties = new HashMap<>();
+
+    // this getter is needed by the framework
+    public Map<String, String> getQuartzProperties() {
+        return quartzProperties;
+    }
 
     @Bean
     @Singleton
     public Scheduler scheduler() throws SchedulerException {
-        // todo: use database as job store
-        StdSchedulerFactory factory = new StdSchedulerFactory();
+        Properties properties = new Properties();
+        properties.putAll(quartzProperties);
+
+        StdSchedulerFactory factory = new StdSchedulerFactory(properties);
         Scheduler scheduler = factory.getScheduler();
 
         scheduler.start();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,3 +27,22 @@ spring:
     abandonWhenPercentageFull: 0
     testOnBorrow: true
     validationQuery: SELECT 1
+
+quartzProperties:
+  org.quartz:
+    scheduler:
+      instanceId: AUTO
+    dataSource:
+      jobscheduler:
+        driver: org.postgresql.Driver
+        URL: ${spring.datasource.url}
+        user: jobscheduler
+        password: test
+    jobStore:
+      isClustered: true
+      class: org.quartz.impl.jdbcjobstore.JobStoreTX
+      driverDelegateClass: org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+      dataSource: jobscheduler
+    threadPool:
+      class: org.quartz.simpl.SimpleThreadPool
+      threadCount: 8


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-141

### Change description ###

Configure Quartz to use the PostgreSQL database as its job data store.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
