### PR TITLE
Configure jobs to request recovery in case of a failover situation

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobsService.java
@@ -33,6 +33,7 @@ public class JobsService {
                 newJob(HttpCallJob.class)
                     .withIdentity(id, serviceName)
                     .usingJobData(HttpCallJob.PARAMS_KEY, serializer.serialize(job.action))
+                    .requestRecovery()
                     .build(),
                 newTrigger()
                     .startAt(Date.from(job.trigger.startDateTime.toInstant()))


### PR DESCRIPTION
### Change description ###

Configure jobs to request recovery in case of a failover situation.

Because Quartz is configured to run in cluster mode, jobs that are in progress when a node fails should be recovered (re-executed).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
