### PR TITLE
Amend triggered action request with S2S header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '1.2.1'
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.2.1'
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.0.4'
 
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-hystrix', version: '1.4.0.RELEASE'
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-hystrix-dashboard', version: '1.4.0.RELEASE'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
         - no_proxy
     environment:
       - S2S_URL
+      - S2S_SECRET
+      - S2S_NAME
+      - S2S_TTL
       - JOB_SCHEDULER_DB_HOST
       - JOB_SCHEDULER_DB_PORT
       - JOB_SCHEDULER_DB_PASSWORD

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ServiceTokenGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ServiceTokenGeneratorConfiguration.java
@@ -18,7 +18,7 @@ public class ServiceTokenGeneratorConfiguration {
 
     @Bean
     public AuthTokenGenerator serviceAuthTokenGenerator(
-        @Value("${idam.s2s-auth.totp_secret}") final String secret,
+        @Value("${idam.s2s-auth.secret}") final String secret,
         @Value("${idam.s2s-auth.microservice}") final String microService,
         final ServiceAuthorisationApi serviceAuthorisationApi
     ) {

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ServiceTokenGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ServiceTokenGeneratorConfiguration.java
@@ -28,7 +28,7 @@ public class ServiceTokenGeneratorConfiguration {
     @Bean
     public AuthTokenGenerator cachedServiceAuthTokenGenerator(
         @Qualifier("serviceAuthTokenGenerator") final AuthTokenGenerator serviceAuthTokenGenerator,
-        @Value("${idam.s2s-auth.tokenTimeToLiveInSeconds:14400}") final int ttl) {
+        @Value("${idam.s2s-auth.tokenTimeToLiveInSeconds}") final int ttl) {
         return new CachedServiceAuthTokenGenerator(serviceAuthTokenGenerator, ttl);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ServiceTokenGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ServiceTokenGeneratorConfiguration.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.jobscheduler.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.netflix.feign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import uk.gov.hmcts.reform.authorisation.ServiceAuthorisationApi;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.CachedServiceAuthTokenGenerator;
+import uk.gov.hmcts.reform.authorisation.generators.ServiceAuthTokenGenerator;
+
+@Configuration
+@Lazy
+@EnableFeignClients(basePackageClasses = ServiceAuthorisationApi.class)
+public class ServiceTokenGeneratorConfiguration {
+
+    @Bean
+    public AuthTokenGenerator serviceAuthTokenGenerator(
+        @Value("${idam.s2s-auth.totp_secret}") final String secret,
+        @Value("${idam.s2s-auth.microservice}") final String microService,
+        final ServiceAuthorisationApi serviceAuthorisationApi
+    ) {
+        return new ServiceAuthTokenGenerator(secret, microService, serviceAuthorisationApi);
+    }
+
+    @Bean
+    public AuthTokenGenerator cachedServiceAuthTokenGenerator(
+        @Qualifier("serviceAuthTokenGenerator") final AuthTokenGenerator serviceAuthTokenGenerator,
+        @Value("${idam.s2s-auth.tokenTimeToLiveInSeconds:14400}") final int ttl) {
+        return new CachedServiceAuthTokenGenerator(serviceAuthTokenGenerator, ttl);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ServiceTokenGeneratorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ServiceTokenGeneratorConfiguration.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.jobscheduler.config;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.netflix.feign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
@@ -17,18 +16,19 @@ import uk.gov.hmcts.reform.authorisation.generators.ServiceAuthTokenGenerator;
 public class ServiceTokenGeneratorConfiguration {
 
     @Bean
-    public AuthTokenGenerator serviceAuthTokenGenerator(
+    public AuthTokenGenerator cachedServiceAuthTokenGenerator(
         @Value("${idam.s2s-auth.secret}") final String secret,
         @Value("${idam.s2s-auth.microservice}") final String microService,
+        @Value("${idam.s2s-auth.tokenTimeToLiveInSeconds}") final int ttl,
         final ServiceAuthorisationApi serviceAuthorisationApi
     ) {
-        return new ServiceAuthTokenGenerator(secret, microService, serviceAuthorisationApi);
-    }
-
-    @Bean
-    public AuthTokenGenerator cachedServiceAuthTokenGenerator(
-        @Qualifier("serviceAuthTokenGenerator") final AuthTokenGenerator serviceAuthTokenGenerator,
-        @Value("${idam.s2s-auth.tokenTimeToLiveInSeconds}") final int ttl) {
-        return new CachedServiceAuthTokenGenerator(serviceAuthTokenGenerator, ttl);
+        return new CachedServiceAuthTokenGenerator(
+            new ServiceAuthTokenGenerator(
+                secret,
+                microService,
+                serviceAuthorisationApi
+            ),
+            ttl
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJob.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJob.java
@@ -4,7 +4,6 @@ import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +25,7 @@ public class HttpCallJob implements Job {
     public HttpCallJob(
         RestTemplate restTemplate,
         ActionExtractor actionExtractor,
-        @Qualifier("cachedServiceAuthTokenGenerator") AuthTokenGenerator tokenGenerator
+        AuthTokenGenerator tokenGenerator
     ) {
         this.restTemplate = restTemplate;
         this.actionExtractor = actionExtractor;

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJob.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJob.java
@@ -38,9 +38,8 @@ public class HttpCallJob implements Job {
         String jobId = context.getJobDetail().getKey().getName();
         logger.info("Executing job " + jobId);
 
-        HttpAction action = actionExtractor.extract(context);
-
-        action.headers.put("ServiceAuthorization", tokenGenerator.generate());
+        HttpAction action = actionExtractor.extract(context)
+            .withHeader("ServiceAuthorization", tokenGenerator.generate());
 
         ResponseEntity<String> response =
             restTemplate

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/model/HttpAction.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/model/HttpAction.java
@@ -5,6 +5,7 @@ import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.URL;
 import org.springframework.http.HttpMethod;
 
+import java.util.HashMap;
 import java.util.Map;
 import javax.validation.constraints.NotNull;
 
@@ -31,5 +32,11 @@ public class HttpAction {
         this.method = method;
         this.headers = headers;
         this.body = body;
+    }
+
+    public HttpAction withHeader(String name, String value) {
+        Map<String, String> newHeaders = new HashMap<>(headers);
+        newHeaders.put(name, value);
+        return new HttpAction(this.url, this.method, newHeaders, this.body);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,6 +8,12 @@ management:
 s2s:
   url: ${S2S_URL}
 
+idam:
+  s2s-auth:
+    url: ${S2S_URL}
+    totp_secret: ${TOTP_SECRET}
+    microservice: jobscheduler
+
 spring:
   datasource:
     url: jdbc:postgresql://${JOB_SCHEDULER_DB_HOST:job-scheduler-database}:${JOB_SCHEDULER_DB_PORT:5432}/jobscheduler

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ s2s:
 idam:
   s2s-auth:
     url: ${S2S_URL}
-    totp_secret: ${S2S_SECRET}
+    secret: ${S2S_SECRET}
     microservice: ${S2S_NAME:jobscheduler}
     tokenTimeToLiveInSeconds: ${S2S_TTL:14400}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ s2s:
 idam:
   s2s-auth:
     url: ${S2S_URL}
-    totp_secret: ${TOTP_SECRET}
+    totp_secret: ${S2S_SECRET}
     microservice: ${S2S_NAME:jobscheduler}
     tokenTimeToLiveInSeconds: ${S2S_TTL:14400}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,7 @@ idam:
     url: ${S2S_URL}
     totp_secret: ${TOTP_SECRET}
     microservice: jobscheduler
+    tokenTimeToLiveInSeconds: 14400
 
 spring:
   datasource:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,7 +12,7 @@ idam:
   s2s-auth:
     url: ${S2S_URL}
     totp_secret: ${TOTP_SECRET}
-    microservice: jobscheduler
+    microservice: ${S2S_NAME:jobscheduler}
     tokenTimeToLiveInSeconds: 14400
 
 spring:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ idam:
     url: ${S2S_URL}
     totp_secret: ${TOTP_SECRET}
     microservice: ${S2S_NAME:jobscheduler}
-    tokenTimeToLiveInSeconds: 14400
+    tokenTimeToLiveInSeconds: ${S2S_TTL:14400}
 
 spring:
   datasource:

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
@@ -42,7 +42,7 @@ public class HttpCallJobTest {
     @Mock private AuthTokenGenerator authTokenGenerator;
 
     @Test
-    public void execute_should_send_http_request_specified_in_job_details() {
+    public void should_send_http_request_specified_in_job_details() {
 
         // given
         stubFor(

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.jobscheduler.jobs;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,8 +11,12 @@ import org.springframework.http.HttpMethod;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.jobscheduler.config.ApplicationConfiguration;
 import uk.gov.hmcts.reform.jobscheduler.model.HttpAction;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
@@ -36,6 +39,7 @@ public class HttpCallJobTest {
 
     @Mock private ActionExtractor actionExtractor;
     @Mock private JobExecutionContext context;
+    @Mock private AuthTokenGenerator authTokenGenerator;
 
     @Test
     public void execute_should_send_http_request_specified_in_job_details() {
@@ -49,21 +53,25 @@ public class HttpCallJobTest {
         given(context.getJobDetail())
             .willReturn(newJob(HttpCallJob.class).withIdentity("id", "group").build());
 
+        Map<String, String> headers = new HashMap<>();
+        headers.put("ServiceAuthorization", "some-token");
+
         given(actionExtractor.extract(context))
             .willReturn(new HttpAction(
                 "http://localhost:8080/hello-world",
                 HttpMethod.POST,
-                ImmutableMap.of("ServiceAuthorization", "some-token"),
+                headers,
                 "some-body"
             ));
 
+        given(authTokenGenerator.generate()).willReturn("newly-generated-token");
         // when
-        new HttpCallJob(restTemplate, actionExtractor).execute(context);
+        new HttpCallJob(restTemplate, actionExtractor, authTokenGenerator).execute(context);
 
         // then
         verify(
             postRequestedFor(urlEqualTo("/hello-world"))
-                .withHeader("ServiceAuthorization", equalTo("some-token"))
+                .withHeader("ServiceAuthorization", equalTo("newly-generated-token"))
                 .withRequestBody(equalTo("some-body"))
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
@@ -54,6 +54,7 @@ public class HttpCallJobTest {
             .willReturn(newJob(HttpCallJob.class).withIdentity("id", "group").build());
 
         Map<String, String> headers = new HashMap<>();
+        headers.put("X-Custom-Header", "anything");
         headers.put("ServiceAuthorization", "some-token");
 
         given(actionExtractor.extract(context))
@@ -71,6 +72,7 @@ public class HttpCallJobTest {
         // then
         verify(
             postRequestedFor(urlEqualTo("/hello-world"))
+                .withHeader("X-Custom-Header", equalTo("anything"))
                 .withHeader("ServiceAuthorization", equalTo("newly-generated-token"))
                 .withRequestBody(equalTo("some-body"))
         );

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.reform.jobscheduler.config.ApplicationConfiguration;
 import uk.gov.hmcts.reform.jobscheduler.model.HttpAction;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -61,8 +60,7 @@ public class HttpCallJobTest {
     @Test
     public void execute_calls_given_endpoint_url() {
         //given
-        Map<String, String> headers = Collections.emptyMap();
-        actionHadHeadersSetTo(headers);
+        actionHadHeadersSetTo(Collections.emptyMap());
 
         // when
         executingHttpCallJob();
@@ -74,8 +72,7 @@ public class HttpCallJobTest {
     @Test
     public void execute_calls_endpoint_with_given_body() {
         //given
-        Map<String, String> headers = Collections.emptyMap();
-        actionHadHeadersSetTo(headers);
+        actionHadHeadersSetTo(Collections.emptyMap());
 
         // when
         executingHttpCallJob();
@@ -90,8 +87,7 @@ public class HttpCallJobTest {
     @Test
     public void execute_adds_service_authorization_header() {
         // given
-        Map<String, String> headers = Collections.emptyMap();
-        actionHadHeadersSetTo(headers);
+        actionHadHeadersSetTo(Collections.emptyMap());
 
         // when
         executingHttpCallJob();
@@ -106,10 +102,7 @@ public class HttpCallJobTest {
     @Test
     public void execute_replaces_existing_service_authorization_header() {
         // given
-        Map<String, String> headers = new HashMap<>();
-        headers.put("ServiceAuthorization", "some-token");
-
-        actionHadHeadersSetTo(headers);
+        actionHadHeadersSetTo(ImmutableMap.of("ServiceAuthorization", "some-token"));
 
         // when
         executingHttpCallJob();
@@ -125,10 +118,7 @@ public class HttpCallJobTest {
     @Test
     public void execute_preserves_non_service_authorization_headers() {
         // given
-        Map<String, String> headers = new HashMap<>();
-        headers.put("X-Custom-Header", "anything");
-
-        actionHadHeadersSetTo(headers);
+        actionHadHeadersSetTo(ImmutableMap.of("X-Custom-Header", "anything"));
 
         // when
         executingHttpCallJob();
@@ -145,7 +135,7 @@ public class HttpCallJobTest {
             .willReturn(new HttpAction(
                 "http://localhost:8080/hello-world",
                 HttpMethod.POST,
-                ImmutableMap.copyOf(headers),
+                headers,
                 "some-body"
             ));
     }

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
@@ -104,7 +104,7 @@ public class HttpCallJobTest {
     }
 
     @Test
-    public void execute_replaced_existing_service_authorization_header() {
+    public void execute_replaces_existing_service_authorization_header() {
         // given
         Map<String, String> headers = new HashMap<>();
         headers.put("ServiceAuthorization", "some-token");

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
@@ -1,8 +1,7 @@
 package uk.gov.hmcts.reform.jobscheduler.jobs;
 
-import com.google.common.collect.ImmutableMap;
-
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.jobscheduler.jobs;
 
+import com.google.common.collect.ImmutableMap;
+
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,7 +63,7 @@ public class HttpCallJobTest {
             .willReturn(new HttpAction(
                 "http://localhost:8080/hello-world",
                 HttpMethod.POST,
-                headers,
+                ImmutableMap.copyOf(headers),
                 "some-body"
             ));
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RPE-173

Job Scheduler needs to authenticate itself to action endpoint. It does
that by generating S2S token and adding it to the request headers.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
