### PR TITLE
Add a tool for rescheduling failed jobs

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/jobs/ActionExtractor.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/jobs/ActionExtractor.java
@@ -4,8 +4,8 @@ import org.quartz.JobExecutionContext;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.jobscheduler.model.HttpAction;
 import uk.gov.hmcts.reform.jobscheduler.services.jobs.ActionSerializer;
+import uk.gov.hmcts.reform.jobscheduler.services.jobs.JobDataKeys;
 
-import static uk.gov.hmcts.reform.jobscheduler.jobs.HttpCallJob.PARAMS_KEY;
 
 @Component
 public class ActionExtractor {
@@ -19,7 +19,7 @@ public class ActionExtractor {
      * Extracts action model from job execution context.
      */
     public HttpAction extract(JobExecutionContext ctx) {
-        String json = ctx.getJobDetail().getJobDataMap().getString(PARAMS_KEY);
+        String json = ctx.getJobDetail().getJobDataMap().getString(JobDataKeys.PARAMS);
         return actionSerializer.deserialize(json);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/FailedJobRescheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/FailedJobRescheduler.java
@@ -1,0 +1,97 @@
+package uk.gov.hmcts.reform.jobscheduler.services.jobs;
+
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobListener;
+import org.quartz.SchedulerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.quartz.TriggerBuilder.newTrigger;
+
+/**
+ * Listens for failed jobs and schedules their re-execution.
+ */
+public class FailedJobRescheduler implements JobListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(FailedJobRescheduler.class);
+
+    private final int maxNumberOfAttempts;
+    private final Duration delayBetweenAttempts;
+
+    public FailedJobRescheduler(int maxNumberOfAttempts, Duration delayBetweenAttempts) {
+        this.maxNumberOfAttempts = maxNumberOfAttempts;
+        this.delayBetweenAttempts = delayBetweenAttempts;
+    }
+
+    @Override
+    public String getName() {
+        return "Failed Job Rescheduler";
+    }
+
+    @Override
+    public void jobToBeExecuted(JobExecutionContext context) {
+        // nothing to do
+    }
+
+    @Override
+    public void jobExecutionVetoed(JobExecutionContext context) {
+        // nothing to do
+    }
+
+    @Override
+    public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+        if (jobException != null) {
+            try {
+                handleFailedJobExecution(context);
+            } catch (Exception e) {
+                logger.error(
+                    "Failed to schedule the re-execution of a previously failed job. Job ID: {}",
+                    context.getJobDetail().getKey().getName(),
+                    e
+                );
+            }
+        }
+    }
+
+    private void handleFailedJobExecution(JobExecutionContext context) throws SchedulerException {
+        String jobId = context.getJobDetail().getKey().getName();
+        int lastAttemptNumber = (Integer)context.getMergedJobDataMap().get(JobDataKeys.ATTEMPT);
+
+        if (lastAttemptNumber < maxNumberOfAttempts) {
+            logger.error("Job execution failed on attempt {}. ID: {}", lastAttemptNumber, jobId);
+            scheduleAnotherExecutionAttempt(context, lastAttemptNumber + 1);
+        } else {
+            logger.error(
+                "Failed to successfully execute job (ID: {}) in {} attempts",
+                jobId,
+                lastAttemptNumber
+            );
+        }
+    }
+
+    private void scheduleAnotherExecutionAttempt(
+        JobExecutionContext lastExecutionContext,
+        int executionAttemptNumber
+    ) throws SchedulerException {
+
+        lastExecutionContext.getScheduler().scheduleJob(
+            newTrigger()
+                .forJob(lastExecutionContext.getJobDetail())
+                .usingJobData(lastExecutionContext.getMergedJobDataMap())
+                .usingJobData(JobDataKeys.ATTEMPT, executionAttemptNumber)
+                .startAt(Date.from(Instant.now().plus(delayBetweenAttempts)))
+                .build()
+        );
+
+        logger.info(
+            "Scheduled re-execution of a failed job (ID: {}). Attempt {}.",
+            lastExecutionContext.getJobDetail().getKey().getName(),
+            executionAttemptNumber
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobDataKeys.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobDataKeys.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.jobscheduler.services.jobs;
+
+/**
+ * Keys that job-scheduler stores in job's JobDataMap.
+ */
+public final class JobDataKeys {
+
+    // job-specific parameters
+    public static final String PARAMS = "params";
+
+    // number of execution attempt
+    public static final String ATTEMPT = "attempt";
+
+    private JobDataKeys() {
+        // hiding default constructor
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobsService.java
@@ -22,6 +22,7 @@ import static org.quartz.JobBuilder.newJob;
 import static org.quartz.TriggerBuilder.newTrigger;
 import static uk.gov.hmcts.reform.jobscheduler.services.jobs.GetterFromScheduler.getFromScheduler;
 
+
 @Service
 public class JobsService {
 
@@ -41,7 +42,8 @@ public class JobsService {
                 newJob(HttpCallJob.class)
                     .withIdentity(id, serviceName)
                     .withDescription(job.name)
-                    .usingJobData(HttpCallJob.PARAMS_KEY, serializer.serialize(job.action))
+                    .usingJobData(JobDataKeys.PARAMS, serializer.serialize(job.action))
+                    .usingJobData(JobDataKeys.ATTEMPT, 1)
                     .requestRecovery()
                     .build(),
                 newTrigger()
@@ -86,7 +88,7 @@ public class JobsService {
     private Job getJobFromDetail(JobDetail jobDetail) {
         return new Job(
             jobDetail.getDescription(),
-            serializer.deserialize(jobDetail.getJobDataMap().getString(HttpCallJob.PARAMS_KEY)),
+            serializer.deserialize(jobDetail.getJobDataMap().getString(JobDataKeys.PARAMS)),
             null
         );
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -53,3 +53,7 @@ quartzProperties:
     threadPool:
       class: org.quartz.simpl.SimpleThreadPool
       threadCount: 8
+
+retryPolicy:
+  maxNumberOfJobExecutions: ${MAX_NUMBER_OF_JOB_EXECUTIONS:5}
+  delayBetweenAttemptsInMs: ${DELAY_BETWEEN_JOB_ATTEMPTS_MS:15000}

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/ActionExtractorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/ActionExtractorTest.java
@@ -8,6 +8,7 @@ import org.quartz.JobExecutionContext;
 import org.springframework.http.HttpMethod;
 import uk.gov.hmcts.reform.jobscheduler.model.HttpAction;
 import uk.gov.hmcts.reform.jobscheduler.services.jobs.ActionSerializer;
+import uk.gov.hmcts.reform.jobscheduler.services.jobs.JobDataKeys;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -36,7 +37,7 @@ public class ActionExtractorTest {
             .willReturn(
                 newJob(HttpCallJob.class)
                     .withIdentity("irrelevant job id", "irrelevant job group")
-                    .usingJobData(HttpCallJob.PARAMS_KEY, serializer.serialize(scheduledAction))
+                    .usingJobData(JobDataKeys.PARAMS, serializer.serialize(scheduledAction))
                     .requestRecovery()
                     .build()
             );

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/FailedJobReschedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/FailedJobReschedulerTest.java
@@ -1,0 +1,186 @@
+package uk.gov.hmcts.reform.jobscheduler.services.jobs;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import uk.gov.hmcts.reform.jobscheduler.jobs.HttpCallJob;
+import wiremock.com.google.common.collect.Maps;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.quartz.JobBuilder.newJob;
+
+public class FailedJobReschedulerTest {
+
+    private static final int MAX_NUMBER_OF_ATTEMPTS = 5;
+    private static final Duration DELAY_BETWEEN_ATTEMPTS = Duration.ofMillis(1000);
+    private static final String ATTEMPT_JOB_DATA_KEY = "attempt";
+
+    private final JobExecutionException jobExecutionException = new JobExecutionException("test");
+
+    private final FailedJobRescheduler rescheduler = new FailedJobRescheduler(
+        MAX_NUMBER_OF_ATTEMPTS,
+        DELAY_BETWEEN_ATTEMPTS
+    );
+
+    @Test
+    public void getName_does_not_throw_exception() {
+        assertThatCode(
+            () -> rescheduler.getName()
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void jobToBeExecuted_does_not_throw_exception() {
+        assertThatCode(
+            () -> rescheduler.jobToBeExecuted(createContext())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void jobExecutionVetoed_does_not_throw_exception() {
+        assertThatCode(
+            () -> rescheduler.jobExecutionVetoed(createContext())
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    public void jobWasExecuted_should_not_reschedule_successful_job() throws Exception {
+        Scheduler scheduler = mock(Scheduler.class);
+        JobExecutionContext context = createContext(
+            scheduler,
+            createJobDetail(),
+            convertToJobDataMap(ImmutableMap.of(ATTEMPT_JOB_DATA_KEY, 1))
+        );
+
+        rescheduler.jobWasExecuted(context, null);
+
+        verify(scheduler, never()).scheduleJob(any());
+    }
+
+    @Test
+    public void jobWasExecuted_should_reschedule_failed_job() throws Exception {
+        // given
+        int lastAttempt = 2;
+        JobDetail jobDetail = createJobDetail();
+        Map<String, Object> originalJobDataMap = createSampleMap(lastAttempt);
+        JobDataMap jobDataMap = convertToJobDataMap(originalJobDataMap);
+        Scheduler scheduler = mock(Scheduler.class);
+        JobExecutionContext context = createContext(scheduler, jobDetail, jobDataMap);
+
+        // when
+        rescheduler.jobWasExecuted(context, jobExecutionException);
+
+        //then
+        Instant rescheduleTime = Instant.now();
+
+        ArgumentCaptor<Trigger> triggerCaptor = ArgumentCaptor.forClass(Trigger.class);
+        verify(scheduler).scheduleJob(triggerCaptor.capture());
+
+        Trigger trigger = triggerCaptor.getValue();
+        assertTriggerStartTimeIsCorrect(trigger, rescheduleTime, DELAY_BETWEEN_ATTEMPTS, 100);
+        assertSameMapWithIncrementedAttempt(trigger.getJobDataMap(), originalJobDataMap);
+        assertThat(trigger.getJobKey()).isEqualTo(jobDetail.getKey());
+    }
+
+    @Test
+    public void jobWasExecuted_should_not_reschedule_failed_job_too_many_times() throws Exception {
+        // given
+        JobDetail jobDetail = createJobDetail();
+        JobDataMap jobDataMap =
+            convertToJobDataMap(ImmutableMap.of(ATTEMPT_JOB_DATA_KEY, MAX_NUMBER_OF_ATTEMPTS));
+
+        Scheduler scheduler = mock(Scheduler.class);
+        JobExecutionContext context = createContext(scheduler, jobDetail, jobDataMap);
+
+        // when
+        rescheduler.jobWasExecuted(context, jobExecutionException);
+
+        // then
+        verify(scheduler, never()).scheduleJob(any());
+    }
+
+    private void assertTriggerStartTimeIsCorrect(
+        Trigger trigger,
+        Instant startOfDelayPeriod,
+        Duration expectedDelay,
+        long accuracyInMs
+    ) {
+        Duration actualDelay =
+            Duration.between(startOfDelayPeriod, trigger.getStartTime().toInstant());
+
+        // check if trigger is set to fire after the expected delay, with 100-millisecond tolerance
+        assertThat(expectedDelay.minus(actualDelay)).isLessThan(Duration.ofMillis(accuracyInMs));
+    }
+
+    private void assertSameMapWithIncrementedAttempt(
+        Map<String, Object> compared,
+        Map<String, Object> original
+    ) {
+        Map<String, Object> expected = incrementAttempt(original);
+
+        assertThat(compared).containsAllEntriesOf(expected);
+        assertThat(compared).hasSameSizeAs(expected);
+    }
+
+    private Map<String, Object> incrementAttempt(Map<String, Object> map) {
+        Map<String, Object> updatedMap = Maps.newHashMap(map);
+        updatedMap.put(ATTEMPT_JOB_DATA_KEY, (int) map.get(ATTEMPT_JOB_DATA_KEY) + 1);
+        return updatedMap;
+    }
+
+    private JobExecutionContext createContext() {
+        return createContext(
+            mock(Scheduler.class),
+            createJobDetail(),
+            convertToJobDataMap(ImmutableMap.of("params", "some params"))
+        );
+    }
+
+    private JobExecutionContext createContext(
+        Scheduler scheduler,
+        JobDetail jobDetail,
+        JobDataMap jobDataMap
+    ) {
+        JobExecutionContext context = mock(JobExecutionContext.class);
+
+        given(context.getJobDetail()).willReturn(jobDetail);
+        given(context.getMergedJobDataMap()).willReturn(jobDataMap);
+        given(context.getScheduler()).willReturn(scheduler);
+
+        return context;
+    }
+
+    private JobDetail createJobDetail() {
+        return newJob(HttpCallJob.class)
+            .withIdentity("id123", "group123")
+            .build();
+    }
+
+    private JobDataMap convertToJobDataMap(Map<?, ?> innerMap) {
+        return new JobDataMap(innerMap);
+    }
+
+    private Map<String, Object> createSampleMap(int attempt) {
+        return ImmutableMap.of(
+            "params", "some params",
+            ATTEMPT_JOB_DATA_KEY, attempt,
+            "more params", "..."
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/jobsservice/CreateJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/jobsservice/CreateJobTest.java
@@ -13,6 +13,7 @@ import org.quartz.Trigger;
 import uk.gov.hmcts.reform.jobscheduler.jobs.HttpCallJob;
 import uk.gov.hmcts.reform.jobscheduler.model.Job;
 import uk.gov.hmcts.reform.jobscheduler.services.jobs.ActionSerializer;
+import uk.gov.hmcts.reform.jobscheduler.services.jobs.JobDataKeys;
 import uk.gov.hmcts.reform.jobscheduler.services.jobs.JobsService;
 import uk.gov.hmcts.reform.jobscheduler.services.jobs.exceptions.JobException;
 
@@ -63,7 +64,7 @@ public class CreateJobTest {
 
         jobsService.create(validJob(), "some service name");
 
-        assertThat(jobDetailPassedToScheduler().getJobDataMap().getString(HttpCallJob.PARAMS_KEY))
+        assertThat(jobDetailPassedToScheduler().getJobDataMap().getString(JobDataKeys.PARAMS))
             .isEqualTo(serializedAction);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/jobsservice/GetAllJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/jobsservice/GetAllJobTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.jobscheduler.jobs.HttpCallJob;
 import uk.gov.hmcts.reform.jobscheduler.model.HttpAction;
 import uk.gov.hmcts.reform.jobscheduler.model.JobList;
 import uk.gov.hmcts.reform.jobscheduler.services.jobs.ActionSerializer;
+import uk.gov.hmcts.reform.jobscheduler.services.jobs.JobDataKeys;
 import uk.gov.hmcts.reform.jobscheduler.services.jobs.JobsService;
 
 import java.util.Collections;
@@ -54,7 +55,7 @@ public class GetAllJobTest {
         JobKey jobKey = new JobKey("name", "group");
 
         JobDataMap jobDataMap = new JobDataMap();
-        jobDataMap.put(HttpCallJob.PARAMS_KEY, "value");
+        jobDataMap.put(JobDataKeys.PARAMS, "value");
 
         JobDetail jobDetail = JobBuilder
             .newJob(HttpCallJob.class)


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-172

### Change description ###

Add a tool for scheduling the re-execution of failed jobs.
This pull request doesn't complete the story. `HttpCallJob` changes will go after this one.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
