### PR TITLE
Flatten json response for GetAll

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/ResponseExceptionHandler.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 
-import static java.util.stream.Collectors.toList;
 import static org.springframework.http.ResponseEntity.status;
 
 @ControllerAdvice
@@ -50,7 +49,7 @@ public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
                 .getFieldErrors()
                 .stream()
                 .map(err -> new FieldError(err.getField(), err.getDefaultMessage()))
-                .collect(toList());
+                .collect(Collectors.toList());
 
         return status(HttpStatus.BAD_REQUEST).body(new ModelValidationError(fieldErrors));
     }

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/model/JobData.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/model/JobData.java
@@ -1,22 +1,16 @@
 package uk.gov.hmcts.reform.jobscheduler.model;
 
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
 public final class JobData {
 
     public final String id;
-    public final String name;
-    public final HttpAction action;
 
-    private JobData(
-        String id,
-        String name,
-        HttpAction action
-    ) {
+    @JsonUnwrapped
+    public final Job job;
+
+    public JobData(String id, Job job) {
         this.id = id;
-        this.name = name;
-        this.action = action;
-    }
-
-    public static JobData fromJob(String id, Job job) {
-        return new JobData(id, job.name, job.action);
+        this.job = job;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobsService.java
@@ -84,7 +84,7 @@ public class JobsService {
             .stream()
             .skip(page * size)
             .limit(size)
-            .map(jobKey -> JobData.fromJob(
+            .map(jobKey -> new JobData(
                 jobKey.getName(),
                 getJobFromDetail(getFromScheduler(scheduler::getJobDetail, jobKey))
             ))

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/controllers/jobscontroller/GetAllTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/controllers/jobscontroller/GetAllTest.java
@@ -65,7 +65,7 @@ public class GetAllTest {
 
     @Test
     public void should_return_default_pages_when_no_parameters_are_passed() throws Exception {
-        JobData jobData = JobData.fromJob("some-id", validJob());
+        JobData jobData = new JobData("some-id", validJob());
         when(jobsService.getAll(anyString(), anyInt(), anyInt()))
             .thenReturn(new Pages<>(Collections.singletonList(jobData)));
 
@@ -73,7 +73,7 @@ public class GetAllTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("content[0].action").exists())
             .andExpect(jsonPath("content[0].id").value(jobData.id))
-            .andExpect(jsonPath("content[0].name").value(jobData.name))
+            .andExpect(jsonPath("content[0].name").value(jobData.job.name))
             .andExpect(jsonPath("total_pages").value(1))
             .andExpect(jsonPath("total_elements").value(1))
             .andExpect(jsonPath("number_of_elements").value(1));
@@ -148,7 +148,7 @@ public class GetAllTest {
         if (copies < 1) {
             jobs = Collections.emptyList();
         } else {
-            jobs = Collections.nCopies(Math.min(copies, size), JobData.fromJob("some-id", validJob()));
+            jobs = Collections.nCopies(Math.min(copies, size), new JobData("some-id", validJob()));
         }
 
         Page<JobData> pages = new Pages<>(jobs, PageRequest.of(page, size), total);

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/jobsservice/GetAllJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/jobsservice/GetAllJobTest.java
@@ -62,7 +62,7 @@ public class GetAllJobTest {
         assertThat(pages1.getTotalElements()).isEqualTo(1);
         assertThat(pages1.getTotalPages()).isEqualTo(1);
         assertThat(pages1.getNumberOfElements()).isEqualTo(1);
-        assertThat(pages1.getContent()).extracting("action", HttpAction.class).isNotEmpty();
+        assertThat(pages1.getContent()).extracting("job.action", HttpAction.class).isNotEmpty();
         assertThat(pages1.getContent()).extracting("id", String.class).containsOnlyOnce("name1");
 
         Page<JobData> pages2 = setUpAndRetrieve(3, 1, 10);


### PR DESCRIPTION
### Change description ###

Instead of listing out all inner properties of the `Job`, use `JsonUnwrapped` annotation instead to flatten the json object field.

P.S. sneaky PMD rule fix introduced in #32 alongside #29 - use class explicitly to easily recognise where function is coming from.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
