### PR TITLE
Re-populate trigger

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/JobsService.java
@@ -12,9 +12,12 @@ import uk.gov.hmcts.reform.jobscheduler.model.Job;
 import uk.gov.hmcts.reform.jobscheduler.model.JobData;
 import uk.gov.hmcts.reform.jobscheduler.model.PageRequest;
 import uk.gov.hmcts.reform.jobscheduler.model.Pages;
+import uk.gov.hmcts.reform.jobscheduler.model.Trigger;
 import uk.gov.hmcts.reform.jobscheduler.services.jobs.exceptions.JobException;
 import uk.gov.hmcts.reform.jobscheduler.services.jobs.exceptions.JobNotFoundException;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -24,7 +27,6 @@ import java.util.stream.Collectors;
 import static org.quartz.JobBuilder.newJob;
 import static org.quartz.TriggerBuilder.newTrigger;
 import static uk.gov.hmcts.reform.jobscheduler.services.jobs.GetterFromScheduler.getFromScheduler;
-
 
 @Service
 public class JobsService {
@@ -46,11 +48,11 @@ public class JobsService {
                     .withIdentity(id, serviceName)
                     .withDescription(job.name)
                     .usingJobData(JobDataKeys.PARAMS, serializer.serialize(job.action))
-                    .usingJobData(JobDataKeys.ATTEMPT, 1)
                     .requestRecovery()
                     .build(),
                 newTrigger()
                     .startAt(Date.from(job.trigger.startDateTime.toInstant()))
+                    .usingJobData(JobDataKeys.ATTEMPT, 1)
                     .build()
             );
 
@@ -94,10 +96,19 @@ public class JobsService {
     }
 
     private Job getJobFromDetail(JobDetail jobDetail) {
+        Trigger trigger = getFromScheduler(scheduler::getTriggersOfJob, jobDetail.getKey())
+            .stream()
+            .filter(quartzTrigger -> quartzTrigger.getJobDataMap().getIntValue(JobDataKeys.ATTEMPT) == 1)
+            .findFirst()
+            .map(quartzTrigger -> new Trigger(
+                ZonedDateTime.ofInstant(quartzTrigger.getStartTime().toInstant(), ZoneId.systemDefault())
+            ))
+            .orElse(null);
+
         return new Job(
             jobDetail.getDescription(),
             serializer.deserialize(jobDetail.getJobDataMap().getString(JobDataKeys.PARAMS)),
-            null
+            trigger
         );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/TriggerConverter.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/TriggerConverter.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.jobscheduler.services.jobs;
+
+import uk.gov.hmcts.reform.jobscheduler.model.Trigger;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+import static org.quartz.TriggerBuilder.newTrigger;
+
+final class TriggerConverter {
+
+    private TriggerConverter() {
+        // static class constructor
+    }
+
+    static org.quartz.Trigger toQuartzTrigger(final Trigger trigger) {
+        return newTrigger()
+            .startAt(Date.from(trigger.startDateTime.toInstant()))
+            .usingJobData(JobDataKeys.ATTEMPT, 1)
+            .build();
+    }
+
+    static Trigger toPlatformTrigger(org.quartz.Trigger trigger) {
+        return new Trigger(
+            ZonedDateTime.ofInstant(trigger.getStartTime().toInstant(), ZoneId.systemDefault())
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/TriggerConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/TriggerConverterTest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.jobscheduler.services.jobs;
+
+import org.junit.Test;
+import org.quartz.SimpleScheduleBuilder;
+import uk.gov.hmcts.reform.jobscheduler.model.Trigger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.jobscheduler.SampleData.validJob;
+
+public class TriggerConverterTest {
+
+    @Test
+    public void should_use_default_scheduler_builder_and_convert_triggers_correctly() {
+        Trigger originalTrigger = validJob().trigger;
+        org.quartz.Trigger trigger = TriggerConverter.toQuartzTrigger(originalTrigger);
+
+        // dummy assertion to remind in the future of different schedulers in use and verify
+        assertThat(trigger.getScheduleBuilder()).isOfAnyClassIn(SimpleScheduleBuilder.class);
+        assertThat(trigger.getJobDataMap().getIntValue(JobDataKeys.ATTEMPT)).isEqualTo(1);
+
+        Trigger rebuiltTrigger = TriggerConverter.toPlatformTrigger(trigger);
+
+        assertThat(rebuiltTrigger).isEqualToComparingFieldByFieldRecursively(originalTrigger);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/TriggerConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/TriggerConverterTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 import org.quartz.SimpleScheduleBuilder;
 import uk.gov.hmcts.reform.jobscheduler.model.Trigger;
 
+import java.sql.Date;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.jobscheduler.SampleData.validJob;
 
@@ -17,6 +19,7 @@ public class TriggerConverterTest {
         // dummy assertion to remind in the future of different schedulers in use and verify
         assertThat(trigger.getScheduleBuilder()).isOfAnyClassIn(SimpleScheduleBuilder.class);
         assertThat(trigger.getJobDataMap().getIntValue(JobDataKeys.ATTEMPT)).isEqualTo(1);
+        assertThat(trigger.getStartTime()).isEqualTo(Date.from(originalTrigger.startDateTime.toInstant()));
 
         Trigger rebuiltTrigger = TriggerConverter.toPlatformTrigger(trigger);
 

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/jobsservice/GetAllJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/jobsservice/GetAllJobTest.java
@@ -11,6 +11,7 @@ import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
+import org.quartz.Trigger;
 import org.springframework.data.domain.Page;
 import uk.gov.hmcts.reform.jobscheduler.jobs.HttpCallJob;
 import uk.gov.hmcts.reform.jobscheduler.model.HttpAction;
@@ -25,10 +26,13 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.quartz.TriggerBuilder.newTrigger;
 import static uk.gov.hmcts.reform.jobscheduler.SampleData.validJob;
 import static uk.gov.hmcts.reform.jobscheduler.services.jobs.GetterFromScheduler.getFromScheduler;
 
@@ -88,6 +92,17 @@ public class GetAllJobTest {
         assertThat(pages5.getNumberOfElements()).isEqualTo(1);
     }
 
+    @Test
+    public void should_recreate_job_from_scheduler_data() throws SchedulerException {
+        Page<JobData> pages = setUpAndRetrieve(1, 0, 1);
+
+        pages.getContent().forEach(jobData -> {
+            assertThat(jobData.id).isEqualTo("name1");
+            assertThat(jobData.job.name).isEqualTo("description");
+            assertThat(jobData.job.trigger).isNotNull();
+        });
+    }
+
     private Page<JobData> setUpAndRetrieve(int total, int page, int size) throws SchedulerException {
         Set<JobKey> keys;
 
@@ -104,8 +119,18 @@ public class GetAllJobTest {
                         .withDescription("description")
                         .usingJobData(jobDataMap)
                         .build();
+                    Trigger trigger = newTrigger()
+                        .usingJobData(JobDataKeys.ATTEMPT, 1)
+                        .build();
 
                     when(getFromScheduler(scheduler::getJobDetail, jobKey)).thenReturn(jobDetail);
+
+                    try {
+                        doReturn(Collections.singletonList(trigger)).when(scheduler).getTriggersOfJob(jobKey);
+                    } catch (SchedulerException exc) {
+                        // capture of generic types of ? extends Smth is impossible with when/then
+                        fail("unable to return job triggers", exc);
+                    }
 
                     return jobKey;
                 })


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Retrieve a list of jobs for a service](https://tools.hmcts.net/jira/browse/RPE-146)

### Change description ###

Branched off #36 with simpler implementation satisfying the current way of trigger implementation.

NB `ATTEMPT` is relevant to job trigger so it is moved to relevant place

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
