### PR TITLE
Don't trace ServiceAuthorization header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.2.1'
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.1.0'
+  compile group: 'uk.gov.hmcts.reform', name: 'reform-api-standards', version: '0.3.0'
 
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-hystrix', version: '1.4.0.RELEASE'
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-hystrix-dashboard', version: '1.4.0.RELEASE'

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/config/ApplicationConfiguration.java
@@ -1,8 +1,11 @@
 package uk.gov.hmcts.reform.jobscheduler.config;
 
+import org.springframework.boot.actuate.trace.TraceProperties;
+import org.springframework.boot.actuate.trace.TraceRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.api.filters.SensitiveHeadersRequestTraceFilter;
 
 @Configuration
 public class ApplicationConfiguration {
@@ -10,5 +13,13 @@ public class ApplicationConfiguration {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    public SensitiveHeadersRequestTraceFilter requestTraceFilter(
+        TraceRepository traceRepository,
+        TraceProperties traceProperties
+    ) {
+        return new SensitiveHeadersRequestTraceFilter(traceRepository, traceProperties);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
@@ -9,16 +9,13 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
-import uk.gov.hmcts.reform.jobscheduler.config.ApplicationConfiguration;
 import uk.gov.hmcts.reform.jobscheduler.model.HttpAction;
 
 import java.util.Collections;

--- a/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/jobscheduler/jobs/HttpCallJobTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Mockito.mock;
 import static org.quartz.JobBuilder.newJob;
 
 @RunWith(SpringRunner.class)
-@ContextConfiguration(classes = ApplicationConfiguration.class)
 public class HttpCallJobTest {
 
     private static final String TEST_PATH = "/hello-world";
@@ -56,7 +55,7 @@ public class HttpCallJobTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule();
 
-    @Autowired RestTemplate restTemplate;
+    private final RestTemplate restTemplate = new RestTemplate();
 
     @Mock private ActionExtractor actionExtractor;
     @Mock private JobExecutionContext context;


### PR DESCRIPTION
trace log available via `/trace` route