### PR TITLE
Manually define jacoco report place

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ jacocoTestReport {
   reports {
     xml.enabled = true
     csv.enabled = false
+    xml.destination file("${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
 }
 


### PR DESCRIPTION
### Change description ###

Jacoco reporting did not build report in the desired place by default and codacy coverage reporting tool could not find it. This PR explicitly says where to publish xml report so coverage is up to date in the codacy ci

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
