### PR TITLE
Move swagger publishing to the end of success scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ script:
   - ./gradlew test jacocoTestReport
 
 after_success:
-  - test "$TRAVIS_BRANCH" = "master" && test "$TRAVIS_PULL_REQUEST" = "false" && sh ./publish-swagger-docs.sh
   - java -cp ./codacy-coverage-reporter-assembly-latest.jar com.codacy.CodacyCoverageReporter -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
+  - test "$TRAVIS_BRANCH" = "master" && test "$TRAVIS_PULL_REQUEST" = "false" && sh ./publish-swagger-docs.sh


### PR DESCRIPTION
### Change description ###

Documentation publisher script runs magical `./gradlew clean` which removes test report

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
