### PR TITLE
Fix smoke tests

### DIFF
--- a/src/smokeTest/java/uk/gov/hmcts/reform/jobscheduler/controllers/JobsControllerSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/jobscheduler/controllers/JobsControllerSmokeTest.java
@@ -3,21 +3,27 @@ package uk.gov.hmcts.reform.jobscheduler.controllers;
 import io.restassured.RestAssured;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.junit4.SpringRunner;
 
-@RunWith(SpringRunner.class)
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
 public class JobsControllerSmokeTest {
 
-    @Value("${default-test-url:http://localhost:8484}")
-    private String testUrl;
-
     @Before
-    public void setup() {
-        System.out.println(testUrl);
-        RestAssured.baseURI = testUrl;
+    public void setup() throws IOException {
+        Map<String, String> env = System.getenv();
+        if (env.get("TEST_URL") == null) {
+            Resource resource = new ClassPathResource("/smoke-application.properties");
+            Properties props = PropertiesLoaderUtils.loadProperties(resource);
+            RestAssured.baseURI = props.getProperty("default-test-url");
+        } else {
+            RestAssured.baseURI = env.get("TEST_URL");
+        }
     }
 
     @Test

--- a/src/smokeTest/java/uk/gov/hmcts/reform/jobscheduler/controllers/JobsControllerSmokeTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/jobscheduler/controllers/JobsControllerSmokeTest.java
@@ -29,6 +29,7 @@ public class JobsControllerSmokeTest {
     @Test
     public void create_jobs_should_require_s2s_auth() {
         RestAssured.given()
+            .relaxedHTTPSValidation()
             .header(HttpHeaders.CONTENT_TYPE, "application/json")
             .when().post("/jobs").then().statusCode(400);
     }
@@ -36,6 +37,7 @@ public class JobsControllerSmokeTest {
     @Test
     public void retrieve_jobs_should_require_s2s_auth() {
         RestAssured.given()
+            .relaxedHTTPSValidation()
             .header(HttpHeaders.CONTENT_TYPE, "application/json")
             .when().get("/jobs").then().statusCode(400);
     }

--- a/src/smokeTest/resources/smoke-application.properties
+++ b/src/smokeTest/resources/smoke-application.properties
@@ -1,1 +1,1 @@
-default-test-url=${TEST_URL}
+default-test-url=http://localhost:8484


### PR DESCRIPTION
Spring Boot was not parsing the env vars or reading the properties file correctly so kept using the localhost:8484 fallback which is incorrect. I've reverted back to using regular java and fixed a bug where Rest Assured was trying to validate the ssl certs by default.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
