### PR TITLE
Fixes references to missing subscription parameter

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -26,6 +26,8 @@ module "job-scheduler-api" {
   location            = "${var.location}"
   env                 = "${var.env}"
   ilbIp               = "${var.ilbIp}"
+  is_frontend         = false
+  subscription        = "${var.subscription}"
 
   app_settings = {
     // logging vars


### PR DESCRIPTION
Fixes after this change to the webapp module: https://github.com/contino/moj-module-webapp/commit/476b4bdca6e2673a789e546faae630ffb11ed8d8
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
