### PR TITLE
Feature: AppInsights setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ repositories {
 }
 
 def versions = [
+  reformLogging: '2.0.0',
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion
 ]
 
@@ -149,8 +150,8 @@ dependencies {
   compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
 
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '1.2.1'
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.2.1'
+  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: versions.reformLogging
+  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.4.2'
   compile group: 'uk.gov.hmcts.reform', name: 'reform-api-standards', version: '0.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ task functional(type: Test) {
   description = "Runs Functional Tests"
   testClassesDirs = sourceSets.functionalTest.output.classesDirs
   classpath = sourceSets.functionalTest.runtimeClasspath
+
+  environment("APPINSIGHTS_INSTRUMENTATIONKEY", "some-key")
 }
 
 compileSmokeTestJava {
@@ -128,6 +130,10 @@ dependencyCheck {
 
 repositories {
   jcenter()
+
+  maven {
+    url "https://dl.bintray.com/hmcts/hmcts-maven"
+  }
 }
 
 def versions = [
@@ -152,6 +158,7 @@ dependencies {
 
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: versions.reformLogging
+  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.4.2'
   compile group: 'uk.gov.hmcts.reform', name: 'reform-api-standards', version: '0.3.0'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,8 @@ idam:
     microservice: ${REFORM_SERVICE_NAME:jobscheduler}
 
 spring:
+  application:
+    name: Job Scheduler
   datasource:
     driverClassName: org.postgresql.Driver
     url: jdbc:postgresql://${JOB_SCHEDULER_DB_HOST:job-scheduler-database}:${JOB_SCHEDULER_DB_PORT:5432}/${JOB_SCHEDULER_DB_NAME:jobscheduler}${JOB_SCHEDULER_DB_CONNECTION_OPTIONS:}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[Metrics](https://tools.hmcts.net/jira/browse/RPE-132)

### Change description ###

Adding latest version of java logging including application insights. since 2.0.0, environment variable has been renamed to `APPINSIGHTS_INSTRUMENTATIONKEY` to match nodejs primary key

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
