### PR TITLE
Corrects prod s2s url and service name

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -29,7 +29,7 @@ variable "test-s2s-url" {
 
 variable "prod-s2s-url" {
   type    = "string"
-  default = "http://betaProdccidamAppLB.reform.hmcts.net:4502"
+  default = "https://prod-s2s-api.reform.hmcts.net:3511"
 }
 
 variable "ilbIp" {}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,7 +10,7 @@ idam:
     useStub: false
     url: ${S2S_URL}
     secret: ${S2S_SECRET}
-    microservice: ${REFORM_SERVICE_NAME:jobscheduler}
+    microservice: jobscheduler
 
 spring:
   application:


### PR DESCRIPTION
Hard coding the microservice name has it needs to match the value in s2s so no point it being possible to pass in.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
