### PR TITLE
Explicitly set project name

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'job-scheduler'


### PR DESCRIPTION
The automatically generated name can sometimes contain characters which are not compatible with SonarQube project keys

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
