### PR TITLE
Fix use of subscription instead of env name

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -6,8 +6,8 @@ data "terraform_remote_state" "core_apps_infrastructure" {
   backend = "azurerm"
 
   config {
-    resource_group_name  = "mgmt-state-store-${var.env}"
-    storage_account_name = "mgmtstatestore${var.env}"
+    resource_group_name  = "mgmt-state-store-${var.subscription}"
+    storage_account_name = "mgmtstatestore${var.subscription}"
     container_name       = "mgmtstatestorecontainer${var.env}"
     key                  = "core-infra/${var.env}/terraform.tfstate"
   }
@@ -17,8 +17,8 @@ data "terraform_remote_state" "core_apps_compute" {
   backend = "azurerm"
 
   config {
-    resource_group_name  = "mgmt-state-store-${var.env}"
-    storage_account_name = "mgmtstatestore${var.env}"
+    resource_group_name  = "mgmt-state-store-${var.subscription}"
+    storage_account_name = "mgmtstatestore${var.subscription}"
     container_name       = "mgmtstatestorecontainer${var.env}"
     key                  = "core-compute/${var.env}/terraform.tfstate"
   }


### PR DESCRIPTION
Resource groups and storage are based on subscription not the environment name

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
