### PR TITLE
Implement AbstractLoggingException

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/logging/ErrorCode.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/logging/ErrorCode.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.reform.jobscheduler.logging;
+
+@SuppressWarnings({"squid:S1118", "HideUtilityClassConstructor"})
+public final class ErrorCode {
+
+    public static final String UNKNOWN = "UNKNOWN";
+}

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobActionSerializationException.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobActionSerializationException.java
@@ -1,8 +1,13 @@
 package uk.gov.hmcts.reform.jobscheduler.services.jobs.exceptions;
 
-public class JobActionSerializationException extends RuntimeException {
+import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+
+import static uk.gov.hmcts.reform.jobscheduler.logging.ErrorCode.UNKNOWN;
+
+public class JobActionSerializationException extends AbstractLoggingException {
 
     public JobActionSerializationException(String message, Throwable cause) {
-        super(message, cause);
+        super(AlertLevel.P2, UNKNOWN, message, cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobException.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobException.java
@@ -1,8 +1,13 @@
 package uk.gov.hmcts.reform.jobscheduler.services.jobs.exceptions;
 
-public class JobException extends RuntimeException {
+import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+
+import static uk.gov.hmcts.reform.jobscheduler.logging.ErrorCode.UNKNOWN;
+
+public class JobException extends AbstractLoggingException {
 
     public JobException(String message, Throwable cause) {
-        super(message, cause);
+        super(AlertLevel.P1, UNKNOWN, message, cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobNotFoundException.java
@@ -1,4 +1,13 @@
 package uk.gov.hmcts.reform.jobscheduler.services.jobs.exceptions;
 
-public class JobNotFoundException extends RuntimeException {
+import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
+import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+
+import static uk.gov.hmcts.reform.jobscheduler.logging.ErrorCode.UNKNOWN;
+
+public class JobNotFoundException extends AbstractLoggingException {
+
+    public JobNotFoundException() {
+        super(AlertLevel.P4, UNKNOWN, (Throwable) null);
+    }
 }


### PR DESCRIPTION
Since [v1.5.0](https://github.com/hmcts/java-logging/releases/tag/1.5.0) every error log must have alert level and error code. Both can be disabled via [environment variables](https://github.com/hmcts/java-logging#additional-logback-configuration)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
