### PR TITLE
Fix SonarQube error on inheritance

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobActionSerializationException.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobActionSerializationException.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.jobscheduler.services.jobs.exceptions;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
 public class JobActionSerializationException extends UnknownErrorCodeException {
 
     public JobActionSerializationException(String message, Throwable cause) {

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobException.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobException.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.jobscheduler.services.jobs.exceptions;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
 public class JobException extends UnknownErrorCodeException {
 
     public JobException(String message, Throwable cause) {

--- a/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/jobscheduler/services/jobs/exceptions/JobNotFoundException.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.jobscheduler.services.jobs.exceptions;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
 public class JobNotFoundException extends UnknownErrorCodeException {
 
     public JobNotFoundException() {


### PR DESCRIPTION
Until we can come up with a way to override limitation of 5 parents this is a quick notice to SonarQube to kindly don't check rule for exception classes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
